### PR TITLE
remove_column cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,10 @@
 AllCops:
   TargetRubyVersion: 2.3
 
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*_spec.rb'
+
 Metrics/LineLength:
   Max: 120 # Default: 80
 

--- a/lib/outrigger/cops/helpers/migration_tags.rb
+++ b/lib/outrigger/cops/helpers/migration_tags.rb
@@ -1,0 +1,73 @@
+module RuboCop
+  module Cop
+    module Migration
+      module Tags
+        def on_class(node)
+          _name, superclass, body = *node
+          unless body && superclass && migration_class_node?(superclass)
+            @in_migration = false
+            return
+          end
+          @in_migration = true
+          @migration_node = node
+          @tag_node = find_tag_node(body)
+          @tags = extract_tags(tag_node)
+          check_migration
+        end
+
+        def check_migration
+          # possibly define in your migration cop
+        end
+
+        def in_migration?
+          @in_migration
+        end
+
+        def migration_node
+          @migration_node
+        end
+
+        def tag_node
+          @tag_node
+        end
+
+        def tags
+          @tags || []
+        end
+
+        private
+
+        def migration_class_node?(node)
+          if node.type == :send # for tagged migrations, ex: ActiveRecord::Migration[5.0]
+            node.children.first == migration_class_node
+          else
+            node == migration_class_node
+          end
+        end
+
+        def migration_class_node
+          s(:const, s(:const, nil, :ActiveRecord), :Migration)
+        end
+
+        def s(name, *args)
+          Parser::AST::Node.new(name, args)
+        end
+
+        def extract_tags(tag_node)
+          return [] unless tag_node
+          tag_node.children.last.to_a.map do |tag|
+            # Symbol check for `tag :predeploy` case
+            # else for `tag [:predeploy, :dynamo]` case
+            tag.is_a?(Symbol) ? tag : tag.to_a.last
+          end
+        end
+
+        def find_tag_node(node)
+          node.type == :begin && node.children.compact.find do |n|
+            n.type == :send && n.to_a[1] == :tag
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/outrigger/cops/migration/remove_column.rb
+++ b/lib/outrigger/cops/migration/remove_column.rb
@@ -1,0 +1,55 @@
+require 'rubocop'
+require_relative '../helpers/migration_tags'
+
+module RuboCop
+  module Cop
+    module Migration
+      class RemoveColumn < Cop
+        include RuboCop::Cop::Migration::Tags
+        MSG = '`remove_column` needs to be in a postdeploy migration'.freeze
+
+        def check_migration
+          return unless banned_tags.empty?
+          add_offense(migration_node,
+                      message: 'No BannedTags have been defined in the RuboCop configuration for' \
+                               ' Migration/RemoveColumn.',
+                      severity: :warning)
+        end
+
+        def on_def(node)
+          return unless in_migration?
+          method_name, *_args = *node
+          @current_def = method_name
+        end
+
+        def on_defs(node)
+          return unless in_migration?
+          _receiver, method_name, *_args = *node
+          @current_def = method_name
+        end
+
+        def on_send(node)
+          return unless in_migration?
+          _receiver, method_name, *_args = *node
+          add_offense(node, message: MSG, severity: :warning) if remove_column_in_predeploy?(method_name)
+        end
+
+        private
+
+        def remove_column_in_predeploy?(method_name)
+          method_name == :remove_column &&
+            @current_def == :up &&
+            banned_tag?
+        end
+
+        def banned_tag?
+          !(tags & banned_tags).empty?
+        end
+
+        def banned_tags
+          cop_config['BannedTags'].to_a.map(&:to_sym)
+        end
+      end
+    end
+  end
+end

--- a/lib/outrigger/cops/migration/tagged.rb
+++ b/lib/outrigger/cops/migration/tagged.rb
@@ -1,40 +1,46 @@
+require 'rubocop'
+require_relative '../helpers/migration_tags'
+
 module RuboCop
   module Cop
     module Migration
       class Tagged < Cop
-        def on_class(node)
-          _name, superclass, body = *node
-          return unless body && superclass == s(:const, s(:const, nil, :ActiveRecord), :Migration)
-          check(node, body)
-        end
+        include RuboCop::Cop::Migration::Tags
 
         private
 
-        def s(name, *args)
-          Parser::AST::Node.new(name, args)
+        def check_migration
+          ensure_allowed_tags
+          ensure_tagged
+          check_bad_tags
         end
 
-        def check(klass, node)
-          tag = tag_node(node)
-
-          if allowed_tags.empty?
-            add_offense(tag, :expression, 'No allowed tags have been defined in the RuboCop configuration.')
-          elsif tag
-            return if allowed_tags.include? tag.children.last.to_a.last
-            add_offense(tag, :expression, "Tags may only be one of #{allowed_tags}.")
-          else
-            add_offense(klass, :expression, "All migrations require a tag from #{allowed_tags}.")
-          end
+        def ensure_allowed_tags
+          return unless allowed_tags.empty?
+          add_offense(migration_node,
+                      message: 'No AllowedTags have been defined in the RuboCop configuration for' \
+                               ' Migration/Tagged.',
+                      severity: :warning)
         end
 
-        def tag_node(node)
-          node.type == :begin && node.children.compact.find do |n|
-            n.type == :send && n.to_a[1] == :tag
+        def ensure_tagged
+          return unless tags.empty?
+          add_offense(migration_node,
+                      message: "All migrations require a tag from #{allowed_tags}.",
+                      severity: :warning)
+        end
+
+        def check_bad_tags
+          tags.each do |tag|
+            next if allowed_tags.include?(tag)
+            add_offense(tag_node,
+                        message: "Tags may only be one of #{allowed_tags}. Bad tag: #{tag}",
+                        severity: :warning)
           end
         end
 
         def allowed_tags
-          cop_config['AllowedTags'].map(&:to_sym)
+          cop_config['AllowedTags'].to_a.map(&:to_sym)
         end
       end
     end

--- a/outrigger.gemspec
+++ b/outrigger.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler', '~> 1.15'
   s.add_development_dependency 'rake', '~> 12.0'
   s.add_development_dependency 'rspec', '~> 3.6.0'
-  s.add_development_dependency 'rubocop', '~> 0.50.0'
+  s.add_development_dependency 'rubocop', '~> 0.52.0'
   s.add_development_dependency 'simplecov', '~> 0'
 end

--- a/spec/outrigger/cops/migration/remove_column_spec.rb
+++ b/spec/outrigger/cops/migration/remove_column_spec.rb
@@ -1,0 +1,198 @@
+require 'spec_helper'
+require 'rubocop/rspec/support'
+require_relative '../../../../lib/outrigger/cops/migration/remove_column'
+
+describe RuboCop::Cop::Migration::RemoveColumn do
+  context 'with nil BannedTags' do
+    let(:config) do
+      RuboCop::Config.new(
+        'Migration/RemoveColumn' => {
+          'Enabled' => true
+        }
+      )
+    end
+
+    subject(:cop) { described_class.new(config) }
+
+    context 'predeploy' do
+      it 'complains about empty banned tags' do
+        inspect_source(%(
+        class MyMigration < ActiveRecord::Migration
+          def up
+            remove_column :x, :y
+          end
+        end
+      ))
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.messages.first).to match(/No BannedTags have been defined in the RuboCop configuration/)
+        expect(cop.offenses.first.severity.name).to eq(:warning)
+      end
+    end
+  end
+
+  context 'with non empty BannedTags' do
+    let(:config) do
+      RuboCop::Config.new(
+        'Migration/RemoveColumn' => {
+          'Enabled' => true,
+          'BannedTags' => ['predeploy']
+        }
+      )
+    end
+
+    subject(:cop) { described_class.new(config) }
+
+    context 'single banned tag' do
+      it 'disallows remove_column in `up`' do
+        inspect_source(%(
+          class MyMigration < ActiveRecord::Migration[5.0]
+            tag :predeploy
+            def up
+              remove_column :x, :y
+            end
+          end
+        ))
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.messages.first).to match(/remove_column/)
+        expect(cop.offenses.first.severity.name).to eq(:warning)
+      end
+
+      it 'disallows remove_column in `self.up`' do
+        inspect_source(%(
+          class MyMigration < ActiveRecord::Migration
+            tag :predeploy
+            def self.up
+              remove_column :x, :y
+            end
+          end
+        ))
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.messages.first).to match(/remove_column/)
+        expect(cop.offenses.first.severity.name).to eq(:warning)
+      end
+
+      it 'allows remove_column in `down`' do
+        inspect_source(%(
+          class MyMigration < ActiveRecord::Migration
+            tag :predeploy
+            def down
+              remove_column :x, :y
+            end
+          end
+        ))
+        expect(cop.offenses.size).to eq(0)
+      end
+
+      it 'allows remove_column in a non migration class `up`' do
+        inspect_source(%{
+          class MyMigration < ActiveRecord::Migration
+            tag :predeploy
+            def down
+              remove_column :x, :y
+            end
+          end
+          class Foobar < ActiveRecord::Base
+            # why you would do this, i know not
+            def up
+              remove_column :x, :y
+            end
+            private
+            def remove_column(x, y)
+              puts x
+              puts y
+            end
+          end
+        })
+        expect(cop.offenses.size).to eq(0)
+      end
+    end
+
+    context 'single allowed tag' do
+      it 'allows remove_column in `up`' do
+        inspect_source(%(
+          class MyMigration < ActiveRecord::Migration
+            tag :postdeploy
+            def up
+              remove_column :x, :y
+            end
+          end
+        ))
+        expect(cop.offenses.size).to eq(0)
+      end
+
+      context 'with AR version tagged migrations' do
+        it 'allows remove_column in `up`' do
+          inspect_source(%(
+          class MyMigration < ActiveRecord::Migration[5.0]
+            tag :postdeploy
+            def up
+              remove_column :x, :y
+            end
+          end
+        ))
+          expect(cop.offenses.size).to eq(0)
+        end
+      end
+    end
+
+    context 'multiple tags including a banned tag' do
+      it 'disallows remove_column in `up`' do
+        inspect_source(%(
+          class MyMigration < ActiveRecord::Migration
+            tag [:predeploy, :dynamo]
+            def up
+              remove_column :x, :y
+            end
+          end
+        ))
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.messages.first).to match(/remove_column/)
+        expect(cop.offenses.first.severity.name).to eq(:warning)
+      end
+
+      context 'with AR version tagged migrations' do
+        it 'disallows remove_column in `up`' do
+          inspect_source(%(
+          class MyMigration < ActiveRecord::Migration[5.0]
+            tag [:predeploy, :dynamo]
+            def up
+              remove_column :x, :y
+            end
+          end
+        ))
+          expect(cop.offenses.size).to eq(1)
+          expect(cop.messages.first).to match(/remove_column/)
+          expect(cop.offenses.first.severity.name).to eq(:warning)
+        end
+      end
+    end
+
+    context 'multiple tags not including a banned tag' do
+      it 'allows remove_column in `up`' do
+        inspect_source(%(
+          class MyMigration < ActiveRecord::Migration
+            tag [:postdeploy, :dynamo]
+            def up
+              remove_column :x, :y
+            end
+          end
+        ))
+        expect(cop.offenses.size).to eq(0)
+      end
+
+      context 'with AR version tagged migrations' do
+        it 'allows remove_column in `up`' do
+          inspect_source(%(
+          class MyMigration < ActiveRecord::Migration[5.0]
+            tag [:postdeploy, :dynamo]
+            def up
+              remove_column :x, :y
+            end
+          end
+        ))
+          expect(cop.offenses.size).to eq(0)
+        end
+      end
+    end
+  end
+end

--- a/spec/outrigger/cops/migration/tagged_spec.rb
+++ b/spec/outrigger/cops/migration/tagged_spec.rb
@@ -1,0 +1,124 @@
+require 'spec_helper'
+require 'rubocop/rspec/support'
+require_relative '../../../../lib/outrigger/cops/migration/tagged'
+
+describe RuboCop::Cop::Migration::Tagged do
+  context 'with empty AllowedTags' do
+    let(:config) do
+      RuboCop::Config.new(
+        'Migration/Tagged' => {
+          'Enabled' => true,
+          'AllowedTags' => []
+        }
+      )
+    end
+
+    subject(:cop) { described_class.new(config) }
+
+    it 'allows if not migration' do
+      inspect_source(%(
+        class Foo
+          def bar
+            puts 'baz'
+          end
+        end
+      ))
+      expect(cop.offenses.size).to eq(0)
+    end
+
+    it 'allows if empty migration' do
+      inspect_source(%(
+        class FooMigration < ActiveRecord::Migration
+        end
+      ))
+      expect(cop.offenses.size).to eq(0)
+    end
+
+    it 'disallows if non-empty migration' do
+      inspect_source(%(
+        class FooMigration < ActiveRecord::Migration
+          def up
+          end
+        end
+      ))
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.messages.first).to match(/No AllowedTags have been defined/)
+      expect(cop.offenses.first.severity.name).to eq(:warning)
+    end
+  end
+
+  context 'with non-empty AllowedTags' do
+    let(:config) do
+      RuboCop::Config.new(
+        'Migration/Tagged' => {
+          'Enabled' => true,
+          'AllowedTags' => ['predeploy']
+        }
+      )
+    end
+
+    subject(:cop) { described_class.new(config) }
+
+    it 'disallows if non-empty migration' do
+      inspect_source(%(
+        class FooMigration < ActiveRecord::Migration
+          def up
+          end
+        end
+      ))
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.messages.first).to match(/All migrations require a tag/)
+      expect(cop.offenses.first.severity.name).to eq(:warning)
+    end
+
+    it 'disallows bad tag' do
+      inspect_source(%(
+        class FooMigration < ActiveRecord::Migration
+          tag :prrreeeedeploy
+          def up
+          end
+        end
+      ))
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.messages.first).to match(/Tags may only be one of \[:predeploy\]. Bad tag: prrreeeedeploy/)
+      expect(cop.offenses.first.severity.name).to eq(:warning)
+    end
+
+    it 'allows good tag' do
+      inspect_source(%(
+        class FooMigration < ActiveRecord::Migration
+          tag :predeploy
+          def up
+          end
+        end
+      ))
+      expect(cop.offenses.size).to eq(0)
+    end
+
+    context 'with AR version tagged migrations' do
+      it 'disallows bad tag' do
+        inspect_source(%(
+        class FooMigration < ActiveRecord::Migration[5.0]
+          tag :prrreeeedeploy
+          def up
+          end
+        end
+      ))
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.messages.first).to match(/Tags may only be one of \[:predeploy\]. Bad tag: prrreeeedeploy/)
+        expect(cop.offenses.first.severity.name).to eq(:warning)
+      end
+
+      it 'allows good tag' do
+        inspect_source(%(
+        class FooMigration < ActiveRecord::Migration[5.0]
+          tag :predeploy
+          def up
+          end
+        end
+      ))
+        expect(cop.offenses.size).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ SimpleCov.start do
   add_filter 'spec'
   track_files 'lib/**/*.rb'
 end
-SimpleCov.minimum_coverage(30) # TODO: add better coverage
+SimpleCov.minimum_coverage(85) # TODO: add better coverage
 
 require 'bundler/setup'
 require 'outrigger'


### PR DESCRIPTION
- bumps rubocop to 0.52.0
- ports remove_column cop from canvas-lms
- fixes remove_column cop to handle multiple tags
- adds tests for tagged cop