### PR TITLE
Fix for Rails 5.2: use migration_context instead of Migrator

### DIFF
--- a/lib/tasks/outrigger.rake
+++ b/lib/tasks/outrigger.rake
@@ -3,7 +3,11 @@ namespace :db do
     desc 'Run migrations for a Tag'
     task tagged: %i[environment load_config] do |_t, args|
       puts("Migrating Tags: #{args.extras}")
-      ActiveRecord::Migrator.migrate(ActiveRecord::Migrator.migrations_paths, &Outrigger.filter(args.extras))
+      if ActiveRecord.gem_version >= Gem::Version.new('5.2.0')
+        ActiveRecord::Base.connection.migration_context.migrate(nil, &Outrigger.filter(args.extras))
+      else
+        ActiveRecord::Migrator.migrate(ActiveRecord::Migrator.migrations_paths, &Outrigger.filter(args.extras))
+      end
     end
   end
 end


### PR DESCRIPTION
Rails 5.2 removes the `ActiveRecord::Migrator.migrate` class method (see [5.1.6 docs](https://www.rubydoc.info/gems/activerecord/5.1.6/ActiveRecord/Migrator) vs [5.2.0 docs](https://www.rubydoc.info/gems/activerecord/5.2.0/ActiveRecord/Migrator)).

This PR updates the `db:migrate:tagged` task to use `ActiveRecord::Base.connection.migration_context.migrate` instead if the Rails version is >= 5.2.0.