### PR TITLE
add support for loading broken migrations during tag filtering

### DIFF
--- a/lib/outrigger.rb
+++ b/lib/outrigger.rb
@@ -8,6 +8,13 @@ require 'outrigger/railtie' if defined? Rails::Railtie
 module Outrigger
   def self.filter(*tags)
     tags = tags.flatten.map(&:to_sym)
-    proc { |migration| (tags - migration.tags).empty? }
+    proc do |migration|
+      begin
+        # check if migration.tags have complete intersection with requested tags
+        (tags - migration.tags).empty?
+      rescue StandardError
+        false
+      end
+    end
   end
 end

--- a/spec/db/migrate/20200108125306_legacy_broken_migration.rb
+++ b/spec/db/migrate/20200108125306_legacy_broken_migration.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class LegacyBrokenMigration < ActiveRecord::Migration[5.0]
+  tag :broken
+
+  BreakableChange.run
+
+  def change
+    UnresolvedModel.run
+  end
+end

--- a/spec/outrigger/outrigger_spec.rb
+++ b/spec/outrigger/outrigger_spec.rb
@@ -14,5 +14,20 @@ describe Outrigger do
       expect(filter.call(MultiMigration)).to eq(true)
       expect(filter.call(PreDeployMigration)).to eq(false)
     end
+
+    it 'should handle broken migrations' do
+      filter = Outrigger.filter(:broken)
+
+      ActiveRecord::Migration.send :include, Outrigger::Taggable
+      ActiveRecord::MigrationProxy.send :include, Outrigger::TaggableProxy
+      legacy_migration = ActiveRecord::MigrationProxy.new(
+        'LegacyBrokenMigration',
+        '20200108125306',
+        'spec/db/migrate/20200108125306_legacy_broken_migration.rb',
+        nil
+      )
+
+      expect(filter.call(legacy_migration)).to eq(false)
+    end
   end
 end


### PR DESCRIPTION
Wrap outrigger filter `Proc` to handle any StandardError caused during loading migrations file. In a scenario, where pending migration has any issue it will be anyway raised in the Rails migration context at the execution time.

Fix #9 