### PR TITLE
Ease dependency on ActiveRecord to support Rails 7

### DIFF
--- a/outrigger.gemspec
+++ b/outrigger.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.6'
 
-  s.add_dependency 'activerecord', '>= 6.0', '< 6.2'
+  s.add_dependency 'activerecord', '>= 6.0', '< 7.1'
 
   s.add_development_dependency 'bundler', '~> 2.2'
   s.add_development_dependency 'byebug', '~> 11.1'


### PR DESCRIPTION
This PR adds support for Rails 7. All tests pass and tagged migrations work as expected after the change.